### PR TITLE
Add remote ADB server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Common Parameters:
   -e, --selector <SELECTOR>  Element selector. Supports CSS-like syntax
   -c, --command <COMMAND>
   -t, --timeout <TIMEOUT>    [default: 30]
+      --remote <REMOTE>      Remote ADB server address (host:port)
 
 Command-Specific Parameters:
       --text <TEXT>        Text content for inputText command
@@ -82,6 +83,21 @@ bochi -e '[resource-id=com.example:id/username]' -c inputText --text "myusername
 
 ```bash
 bochi -s emulator-5554 -e '[resource-id=com.example:id/button]' -c tap
+```
+
+### Connect to remote ADB server
+
+```bash
+bochi --remote 127.0.0.1:5037 -e '[text=Submit]' -c tap
+```
+
+Both host and port must be specified. This translates to `adb -H host -P port` commands internally. 
+The remote ADB server must be started with `-a` to accept external connections.
+
+For IPv6 addresses, use brackets:
+
+```bash
+bochi --remote '[::1]:5037' -e '[text=Submit]' -c tap
 ```
 
 ### Set custom timeout

--- a/SKILL.md
+++ b/SKILL.md
@@ -314,7 +314,7 @@ Connect to a remote ADB server instead of the local one:
 
 ```bash
 # Connect to remote ADB server at 127.0.0.1:5554
-bochi --remote 127.0.0.1:5037' -e '[text=Submit]' -c tap
+bochi --remote 127.0.0.1:5037 -e '[text=Submit]' -c tap
 
 # For IPv6 addresses, use brackets
 bochi --remote '[::1]:5037' -e '[text=Submit]' -c tap

--- a/SKILL.md
+++ b/SKILL.md
@@ -47,6 +47,7 @@ Common Parameters:
   -e, --selector <SELECTOR>  Element selector. Supports CSS-like syntax: - [attr=value] - attribute assertion - [attr1=v1][attr2=v2] - AND of clauses - sel1,sel2 - OR of selectors - :has(cond) - has descendant matching cond
   -c, --command <COMMAND>
   -t, --timeout <TIMEOUT>    [default: 30]
+      --remote <REMOTE>      Remote ADB server address (host:port)
 
 Command-Specific Parameters:
       --text <TEXT>        Text content for inputText command
@@ -305,6 +306,24 @@ bochi -e '[class$=RecyclerView]>[class$=LinearLayout]>[text=Settings]' -c tap
 
 ```bash
 bochi -s emulator-5554 -e '[resource-id=com.example:id/button]' -c tap
+```
+
+### Connect to remote ADB server
+
+Connect to a remote ADB server instead of the local one:
+
+```bash
+# Connect to remote ADB server at 127.0.0.1:5554
+bochi --remote 127.0.0.1:5037' -e '[text=Submit]' -c tap
+
+# For IPv6 addresses, use brackets
+bochi --remote '[::1]:5037' -e '[text=Submit]' -c tap
+```
+
+Both host and port must be specified. This translates to `adb -H host -P port` commands internally. 
+The remote ADB server must be started with `-a` to accept external connections. For example,
+```bash 
+adb -a nodaemon server
 ```
 
 ### Set custom timeout

--- a/src/adb_utils.rs
+++ b/src/adb_utils.rs
@@ -1,8 +1,129 @@
 use std::io;
 use std::process::Command;
 
-pub fn get_adb_command(serial: Option<&str>) -> io::Result<Command> {
+/// Parse a remote string in format "host:port"
+/// Returns (host, port) - port must be explicitly specified
+pub fn parse_remote(remote: &str) -> Result<(&str, &str), String> {
+    if remote.is_empty() {
+        return Err("Remote address cannot be empty".to_string());
+    }
+    
+    // Handle IPv6 addresses in brackets like [::1]:5037
+    if remote.starts_with('[') {
+        if let Some(idx) = remote.find("]:") {
+            let host = &remote[..idx + 1]; // Include the brackets
+            let port = &remote[idx + 2..];
+            if port.is_empty() {
+                return Err("Port cannot be empty".to_string());
+            }
+            return Ok((host, port));
+        } else if remote.ends_with(']') {
+            // IPv6 without port - error
+            return Err("Port must be specified (e.g., [::1]:5037)".to_string());
+        }
+    }
+    
+    // Standard host:port format
+    if let Some(idx) = remote.rfind(':') {
+        // Check if this is an IPv6 address without brackets (contains multiple colons)
+        let colon_count = remote.matches(':').count();
+        if colon_count == 1 {
+            // Regular host:port
+            let host = &remote[..idx];
+            let port = &remote[idx + 1..];
+            if host.is_empty() {
+                return Err("Host cannot be empty".to_string());
+            }
+            if port.is_empty() {
+                return Err("Port cannot be empty".to_string());
+            }
+            return Ok((host, port));
+        } else {
+            // IPv6 without brackets - error
+            return Err("IPv6 addresses must be enclosed in brackets (e.g., [::1]:5037)".to_string());
+        }
+    }
+    
+    // Just host without port - error
+    Err("Port must be specified in host:port format (e.g., 127.0.0.1:5037)".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_remote_valid_ipv4() {
+        assert_eq!(parse_remote("127.0.0.1:5037"), Ok(("127.0.0.1", "5037")));
+        assert_eq!(parse_remote("192.168.1.100:5555"), Ok(("192.168.1.100", "5555")));
+    }
+
+    #[test]
+    fn test_parse_remote_valid_hostname() {
+        assert_eq!(parse_remote("localhost:5037"), Ok(("localhost", "5037")));
+        assert_eq!(parse_remote("adb-server.example.com:5555"), Ok(("adb-server.example.com", "5555")));
+    }
+
+    #[test]
+    fn test_parse_remote_valid_ipv6() {
+        assert_eq!(parse_remote("[::1]:5037"), Ok(("[::1]", "5037")));
+        assert_eq!(parse_remote("[2001:db8::1]:5555"), Ok(("[2001:db8::1]", "5555")));
+    }
+
+    #[test]
+    fn test_parse_remote_missing_port() {
+        assert!(parse_remote("127.0.0.1").is_err());
+        assert!(parse_remote("localhost").is_err());
+        assert!(parse_remote("[::1]").is_err());
+    }
+
+    #[test]
+    fn test_parse_remote_empty() {
+        assert!(parse_remote("").is_err());
+    }
+
+    #[test]
+    fn test_parse_remote_empty_host() {
+        assert!(parse_remote(":5037").is_err());
+    }
+
+    #[test]
+    fn test_parse_remote_empty_port() {
+        assert!(parse_remote("127.0.0.1:").is_err());
+        assert!(parse_remote("localhost:").is_err());
+        assert!(parse_remote("[::1]:").is_err());
+    }
+
+    #[test]
+    fn test_parse_remote_ipv6_without_brackets() {
+        assert!(parse_remote("::1:5037").is_err());
+        assert!(parse_remote("2001:db8::1:5037").is_err());
+    }
+
+    #[test]
+    fn test_parse_remote_multiple_colons_not_ipv6() {
+        // This should fail because it looks like IPv6 without brackets
+        assert!(parse_remote("a:b:c:5037").is_err());
+    }
+}
+
+pub fn get_adb_command(serial: Option<&str>, remote: Option<&str>) -> io::Result<Command> {
     let mut cmd = Command::new("adb");
+    
+    // Add remote host/port if specified (must come before -s)
+    if let Some(r) = remote {
+        match parse_remote(r) {
+            Ok((host, port)) => {
+                cmd.arg("-H").arg(host);
+                cmd.arg("-P").arg(port);
+            }
+            Err(e) => {
+                // Return an io::Error with custom message
+                return Err(io::Error::new(io::ErrorKind::InvalidInput, e));
+            }
+        }
+    }
+    
     if let Some(s) = serial {
         cmd.arg("-s").arg(s);
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -14,10 +14,10 @@ pub fn get_element_center(element: &UiElement) -> (i32, i32) {
     (center_x, center_y)
 }
 
-pub fn tap_element(serial: Option<&str>, element: &UiElement) -> Result<(), String> {
+pub fn tap_element(serial: Option<&str>, remote: Option<&str>, element: &UiElement) -> Result<(), String> {
     let (center_x, center_y) = get_element_center(element);
 
-    let output = get_adb_command(serial)
+    let output = get_adb_command(serial, remote)
         .map_err(|e| format_adb_error(&e))?
         .args([
             "shell",
@@ -41,13 +41,14 @@ pub fn tap_element(serial: Option<&str>, element: &UiElement) -> Result<(), Stri
 
 pub fn long_tap_element(
     serial: Option<&str>,
+    remote: Option<&str>,
     element: &UiElement,
     duration_ms: u64,
 ) -> Result<(), String> {
     let (center_x, center_y) = get_element_center(element);
 
     // Use swipe with same start and end position to simulate a long press
-    let output = get_adb_command(serial)
+    let output = get_adb_command(serial, remote)
         .map_err(|e| format_adb_error(&e))?
         .args([
             "shell",
@@ -72,20 +73,20 @@ pub fn long_tap_element(
     Ok(())
 }
 
-pub fn double_tap_element(serial: Option<&str>, element: &UiElement) -> Result<(), String> {
+pub fn double_tap_element(serial: Option<&str>, remote: Option<&str>, element: &UiElement) -> Result<(), String> {
     // First tap
-    tap_element(serial, element)?;
+    tap_element(serial, remote, element)?;
 
     // Small delay between taps (typical double tap timing)
     thread::sleep(Duration::from_millis(100));
 
     // Second tap
-    tap_element(serial, element)
+    tap_element(serial, remote, element)
 }
 
 /// Get the screen dimensions (width, height)
-pub fn get_screen_dimensions(serial: Option<&str>) -> Result<(i32, i32), String> {
-    let output = get_adb_command(serial)
+pub fn get_screen_dimensions(serial: Option<&str>, remote: Option<&str>) -> Result<(i32, i32), String> {
+    let output = get_adb_command(serial, remote)
         .map_err(|e| format_adb_error(&e))?
         .args(["shell", "wm", "size"])
         .output()
@@ -122,13 +123,14 @@ pub fn parse_screen_dimensions(output: &str) -> Result<(i32, i32), String> {
 /// Perform a swipe gesture
 pub fn perform_swipe(
     serial: Option<&str>,
+    remote: Option<&str>,
     x1: i32,
     y1: i32,
     x2: i32,
     y2: i32,
     duration_ms: u64,
 ) -> Result<(), String> {
-    let output = get_adb_command(serial)
+    let output = get_adb_command(serial, remote)
         .map_err(|e| format_adb_error(&e))?
         .args([
             "shell",
@@ -185,6 +187,7 @@ pub fn calculate_scroll_coordinates(
 /// Scroll gradually until the target element is visible
 pub fn scroll_until_visible(
     serial: Option<&str>,
+    remote: Option<&str>,
     scroll_selector: &Selector,
     target_selector: &Selector,
     timeout_secs: u64,
@@ -194,7 +197,7 @@ pub fn scroll_until_visible(
     let timeout = Duration::from_secs(timeout_secs);
 
     // Get screen dimensions
-    let (screen_width, screen_height) = get_screen_dimensions(serial)?;
+    let (screen_width, screen_height) = get_screen_dimensions(serial, remote)?;
 
     // Swipe duration in ms - moderate speed for smooth scrolling
     let swipe_duration = 300;
@@ -208,7 +211,7 @@ pub fn scroll_until_visible(
         }
 
         // Get current UI hierarchy
-        let xml = get_ui_hierarchy(serial)?;
+        let xml = get_ui_hierarchy(serial, remote)?;
 
         // First, check if target is already visible
         let target_elements = find_elements(&xml, target_selector)?;
@@ -231,22 +234,22 @@ pub fn scroll_until_visible(
         let scroll_element = &scroll_elements[0];
         let (x1, y1, x2, y2) = calculate_scroll_coordinates(scroll_element, screen_height, scroll_up);
 
-        perform_swipe(serial, x1, y1, x2, y2, swipe_duration)?;
+        perform_swipe(serial, remote, x1, y1, x2, y2, swipe_duration)?;
 
         // Small delay between swipes to let UI settle
         thread::sleep(Duration::from_millis(500));
     }
 }
 
-pub fn input_text_element(serial: Option<&str>, element: &UiElement, text: &str) -> Result<(), String> {
+pub fn input_text_element(serial: Option<&str>, remote: Option<&str>, element: &UiElement, text: &str) -> Result<(), String> {
     // First tap to focus on the element
-    tap_element(serial, element)?;
+    tap_element(serial, remote, element)?;
 
     // Small delay to ensure the element is focused
     thread::sleep(Duration::from_millis(100));
 
     // Then type the text
-    let output = get_adb_command(serial)
+    let output = get_adb_command(serial, remote)
         .map_err(|e| format_adb_error(&e))?
         .args(["shell", "input", "text", text])
         .output()
@@ -264,15 +267,17 @@ pub fn input_text_element(serial: Option<&str>, element: &UiElement, text: &str)
 
 pub fn wait_for_element(
     serial: Option<&str>,
+    remote: Option<&str>,
     selector: &Selector,
     timeout_secs: u64,
 ) -> Result<UiElement, String> {
-    wait_for_elements(serial, selector, timeout_secs, false)
+    wait_for_elements(serial, remote, selector, timeout_secs, false)
         .map(|elements| elements.into_iter().next().unwrap())
 }
 
 pub fn wait_for_elements(
     serial: Option<&str>,
+    remote: Option<&str>,
     selector: &Selector,
     timeout_secs: u64,
     with_descendants: bool,
@@ -288,7 +293,7 @@ pub fn wait_for_elements(
             ));
         }
 
-        let xml = get_ui_hierarchy(serial)?;
+        let xml = get_ui_hierarchy(serial, remote)?;
         let elements = if with_descendants {
             find_elements_with_descendants(&xml, selector)?
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,20 @@ struct Cli {
     #[arg(short, long, help_heading = "Common Parameters", display_order = 1)]
     serial: Option<String>,
 
+    /// Remote ADB server address in host:port format (e.g., 127.0.0.1:5037)
+    #[arg(
+        long,
+        help = "Remote ADB server address (host:port)",
+        long_help = r#"Remote ADB server address in host:port format.
+
+Connects to a remote ADB server instead of the local one.
+Example: --remote 127.0.0.1:5037
+Both host and port must be specified."#,
+        help_heading = "Common Parameters",
+        display_order = 5
+    )]
+    remote: Option<String>,
+
     /// Element selector
     #[arg(
         short = 'e',
@@ -123,6 +137,7 @@ fn main() {
     let result = match cli.command {
         BochiCommand::WaitFor => wait_for_elements(
             cli.serial.as_deref(),
+            cli.remote.as_deref(),
             &selector,
             cli.timeout,
             cli.print_descendants,
@@ -133,27 +148,27 @@ fn main() {
             }
         }),
         BochiCommand::Tap => {
-            match wait_for_element(cli.serial.as_deref(), &selector, cli.timeout) {
-                Ok(element) => tap_element(cli.serial.as_deref(), &element),
+            match wait_for_element(cli.serial.as_deref(), cli.remote.as_deref(), &selector, cli.timeout) {
+                Ok(element) => tap_element(cli.serial.as_deref(), cli.remote.as_deref(), &element),
                 Err(e) => Err(e),
             }
         }
         BochiCommand::InputText => match cli.text {
-            Some(text) => match wait_for_element(cli.serial.as_deref(), &selector, cli.timeout) {
-                Ok(element) => input_text_element(cli.serial.as_deref(), &element, &text),
+            Some(text) => match wait_for_element(cli.serial.as_deref(), cli.remote.as_deref(), &selector, cli.timeout) {
+                Ok(element) => input_text_element(cli.serial.as_deref(), cli.remote.as_deref(), &element, &text),
                 Err(e) => Err(e),
             },
             None => Err("--text parameter is required for inputText command".to_string()),
         },
         BochiCommand::LongTap => {
-            match wait_for_element(cli.serial.as_deref(), &selector, cli.timeout) {
-                Ok(element) => long_tap_element(cli.serial.as_deref(), &element, 1000),
+            match wait_for_element(cli.serial.as_deref(), cli.remote.as_deref(), &selector, cli.timeout) {
+                Ok(element) => long_tap_element(cli.serial.as_deref(), cli.remote.as_deref(), &element, 1000),
                 Err(e) => Err(e),
             }
         }
         BochiCommand::DoubleTap => {
-            match wait_for_element(cli.serial.as_deref(), &selector, cli.timeout) {
-                Ok(element) => double_tap_element(cli.serial.as_deref(), &element),
+            match wait_for_element(cli.serial.as_deref(), cli.remote.as_deref(), &selector, cli.timeout) {
+                Ok(element) => double_tap_element(cli.serial.as_deref(), cli.remote.as_deref(), &element),
                 Err(e) => Err(e),
             }
         }
@@ -161,6 +176,7 @@ fn main() {
             Some(target_str) => match Selector::parse(&target_str) {
                 Ok(target_selector) => scroll_until_visible(
                     cli.serial.as_deref(),
+                    cli.remote.as_deref(),
                     &selector,
                     &target_selector,
                     cli.timeout,
@@ -174,6 +190,7 @@ fn main() {
             Some(target_str) => match Selector::parse(&target_str) {
                 Ok(target_selector) => scroll_until_visible(
                     cli.serial.as_deref(),
+                    cli.remote.as_deref(),
                     &selector,
                     &target_selector,
                     cli.timeout,

--- a/src/ui_element.rs
+++ b/src/ui_element.rs
@@ -20,8 +20,8 @@ pub fn is_element_visible(element: &UiElement, screen_width: i32, screen_height:
     has_horizontal_overlap && has_vertical_overlap
 }
 
-pub fn get_ui_hierarchy(serial: Option<&str>) -> Result<String, String> {
-    let output = get_adb_command(serial)
+pub fn get_ui_hierarchy(serial: Option<&str>, remote: Option<&str>) -> Result<String, String> {
+    let output = get_adb_command(serial, remote)
         .map_err(|e| format_adb_error(&e))?
         .args(["shell", "uiautomator", "dump", "/sdcard/window_dump.xml"])
         .output()
@@ -34,7 +34,7 @@ pub fn get_ui_hierarchy(serial: Option<&str>) -> Result<String, String> {
         ));
     }
 
-    let output = get_adb_command(serial)
+    let output = get_adb_command(serial, remote)
         .map_err(|e| format_adb_error(&e))?
         .args(["shell", "cat", "/sdcard/window_dump.xml"])
         .output()


### PR DESCRIPTION
Adds a new --remote flag to connect to a remote ADB server (host:port). This feature enables:

* Connecting to remote ADB servers instead of only local connections
* Supporting both IPv4 (127.0.0.1:5037) and IPv6 ([::1]:5037) addresses
* Proper parsing and validation of remote address format
* Integration with all existing commands (tap, inputText, waitFor, etc.)

Updated documentation in README.md and SKILL.md with usage examples and IPv6 syntax notes.